### PR TITLE
Persist Light/Dark Mode Across Page Refreshes

### DIFF
--- a/src/atoms/themeModeAtom.ts
+++ b/src/atoms/themeModeAtom.ts
@@ -3,4 +3,16 @@ import { atom } from "recoil";
 export const themeModeAtom = atom<"light" | "dark">({
     key: "themeMode",
     default: "light",
+    effects: [({ setSelf, onSet }) => {
+        // Load from localStorage on initialization
+        const savedMode = localStorage.getItem("themeMode") as "light" | "dark" | null;
+        if (savedMode === "light" || savedMode === "dark") {
+            setSelf(savedMode);
+        }
+
+        // Save to localStorage whenever it changes
+        onSet((newValue) => {
+            localStorage.setItem("themeMode", newValue);
+        });
+    }]
 });


### PR DESCRIPTION
This is done by adding effects to the themeModeAtom. In effects, we read/write the current state of the theme to and from local storage.