### PR TITLE
Add 'Financial Modeling Prep (FMP)' Service

### DIFF
--- a/src/components/DataTile.tsx
+++ b/src/components/DataTile.tsx
@@ -4,6 +4,7 @@ import type { QuoteResponse } from "../types/QuoteResponse";
 import { getQuote } from "../services/finnhubService";
 import DataTileRow from "./DataTileRow";
 import FavoriteButton from "./FavoriteButton";
+import { getDividends } from "../services/financialModelingPrepService";
 
 type DataTileProps = {
   symbol: string;
@@ -16,6 +17,12 @@ export default function DataTile({ symbol }: DataTileProps) {
   useEffect(() => {
     async function fetchData() {
       const data = await getQuote(symbol);
+
+      //begin dividend endpoint test
+      const dividends = await getDividends(symbol);
+      console.log(dividends);
+      //end dividend endpoint test
+
       setQuote(data);
     }
     fetchData();

--- a/src/services/financialModelingPrepService.ts
+++ b/src/services/financialModelingPrepService.ts
@@ -1,0 +1,19 @@
+import type { DividendsResponse } from "../types/DividendsResponse";
+
+const API_KEY = import.meta.env.VITE_FMP_API_KEY;
+const BASE_URL = 'https://financialmodelingprep.com/stable/';
+
+export async function getDividends(symbol: string): Promise<DividendsResponse | null> {
+    const url = `${BASE_URL}dividends?symbol=${symbol}&apikey=${API_KEY}`;
+
+    try { 
+        const result = await fetch(url);
+        if (!result.ok) {
+            throw new Error(`Financial Modeling Group error: ${result.status}`);
+        }
+        return await result.json();
+    } catch (error) {
+        console.error("Error fetching dividends: ", error);
+        return null;
+    }
+}

--- a/src/services/finnhubService.ts
+++ b/src/services/finnhubService.ts
@@ -13,7 +13,7 @@ export async function getQuote(ticker: string): Promise<QuoteResponse | null> {
     }
     return await result.json();
   } catch (error) {
-    console.error("Error fetching quote:", error);
+    console.error("Error fetching quote: ", error);
     return null;
   }
 }

--- a/src/types/DividendsResponse.ts
+++ b/src/types/DividendsResponse.ts
@@ -1,0 +1,13 @@
+export interface DividendsEntry {
+  symbol: string;
+  date: string;
+  recordDate: string;
+  paymentDate: string;
+  declarationDate: string;
+  adjDividend: number;
+  dividend: number;
+  yield: number;
+  frequency: string;
+}
+
+export type DividendsResponse = DividendsEntry[];


### PR DESCRIPTION
Need another service (data source) to fill holes left by finnhub. Decided to add Financial Modeling Prep due to it's dividend endpoints which will be pivotal to development.