### PR TITLE
Add Navbar Spacer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useRecoilValue } from "recoil";
 import Quote from "./pages/Quote";
 import FavoritePage from "./pages/FavoritePage";
 import NotFoundPage from "./pages/NotFoundPage";
+import NavBarSpacer from "./components/layout/NavBarSpacer";
 
 function App() {
   const themeMode = useRecoilValue(themeModeAtom);
@@ -48,6 +49,7 @@ function App() {
       <CssBaseline />
       <HashRouter>
         <NavBar />
+        <NavBarSpacer />
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/quote" element={<Quote />} />

--- a/src/components/layout/NavBarSpacer.tsx
+++ b/src/components/layout/NavBarSpacer.tsx
@@ -1,0 +1,17 @@
+/**
+ * NavBarSpacer
+ *
+ * MUI AppBar uses a Toolbar internally, and its height isn't automatically
+ * accounted for in page layout. MUI's recommended pattern is to render an
+ * empty <Toolbar /> below the AppBar to create the correct vertical offset.
+ *
+ * This component wraps that pattern so the intent is explicit and readable.
+ * Anywhere you place <NavBarSpacer />, it ensures content won't be hidden
+ * behind the fixed AppBar.
+ */
+
+import { Toolbar } from "@mui/material";
+
+export default function NavBarSpacer() {
+  return <Toolbar />;
+}


### PR DESCRIPTION
Add a spacer below the navbar to fix a bug where content was sliding beneath it.

MUI's recommended fix for this is to add a blank toolbar component below the navbar as a spacer.

Personally, I didn't like how this reads semantically so I added a wrapper called NavBarSpacer so that it is more intuitive to read the code. 

I then left a comment block on the wrapper stating why this decision was made